### PR TITLE
output metafile so users can easily find out what's in the lit action bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/vincent-scaffold-sdk",
-  "version": "1.1.6",
+  "version": "1.1.7-alpha.0",
   "description": "Shared build configuration and utilities for Vincent tools and policies",
   "main": "index.js",
   "bin": {

--- a/src/commands/pkg.js
+++ b/src/commands/pkg.js
@@ -1,14 +1,14 @@
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
-const { isVincentProject } = require('../utils/project-utils');
+const fs = require("fs");
+const path = require("path");
+const chalk = require("chalk");
+const { isVincentProject } = require("../utils/project-utils");
 
 // Import build dependencies
 let esbuild;
 let buildConfig;
 try {
-  esbuild = require('esbuild');
-  buildConfig = require('../esbuild-share-config');
+  esbuild = require("esbuild");
+  buildConfig = require("../esbuild-share-config");
 } catch (err) {
   // Build dependencies not available
 }
@@ -17,21 +17,21 @@ try {
  * Build current package
  */
 async function buildCurrentPackage() {
-  console.log(chalk.cyan.bold('\n📦 Building Current Package\n'));
+  console.log(chalk.cyan.bold("\n📦 Building Current Package\n"));
 
   // Check if current directory is a Vincent package
   const currentProject = isVincentProject(process.cwd());
 
   if (!currentProject.isProject) {
-    console.error(chalk.red('❌ Current directory is not a Vincent package'));
+    console.error(chalk.red("❌ Current directory is not a Vincent package"));
     console.log(
       chalk.gray(
-        'Run this command from within a Vincent tool or policy directory'
+        "Run this command from within a Vincent tool or policy directory"
       )
     );
     console.log(
       chalk.gray(
-        'Or use \'vincent-scaffold build\' from the project root for project-level operations'
+        "Or use 'vincent-scaffold build' from the project root for project-level operations"
       )
     );
     process.exit(1);
@@ -48,21 +48,21 @@ async function buildCurrentPackage() {
  * Deploy current package
  */
 async function deployCurrentPackage() {
-  console.log(chalk.cyan.bold('\n🚀 Deploying Current Package\n'));
+  console.log(chalk.cyan.bold("\n🚀 Deploying Current Package\n"));
 
   // Check if current directory is a Vincent package
   const currentProject = isVincentProject(process.cwd());
 
   if (!currentProject.isProject) {
-    console.error(chalk.red('❌ Current directory is not a Vincent package'));
+    console.error(chalk.red("❌ Current directory is not a Vincent package"));
     console.log(
       chalk.gray(
-        'Run this command from within a Vincent tool or policy directory'
+        "Run this command from within a Vincent tool or policy directory"
       )
     );
     console.log(
       chalk.gray(
-        'Or use \'vincent-scaffold deploy\' from the project root for project-level operations'
+        "Or use 'vincent-scaffold deploy' from the project root for project-level operations"
       )
     );
     process.exit(1);
@@ -72,7 +72,7 @@ async function deployCurrentPackage() {
   console.log(chalk.cyan(`📁 Type: ${currentProject.type}`));
 
   // First build, then deploy
-  console.log(chalk.cyan('\n🔨 Building package before deployment...\n'));
+  console.log(chalk.cyan("\n🔨 Building package before deployment...\n"));
   await buildProject(currentProject.type, currentProject.path);
   await deployProject(currentProject.type, currentProject.path);
 }
@@ -81,16 +81,16 @@ async function deployCurrentPackage() {
  * Clean current package
  */
 async function cleanCurrentPackage() {
-  console.log(chalk.cyan.bold('\n🧹 Cleaning Current Package\n'));
+  console.log(chalk.cyan.bold("\n🧹 Cleaning Current Package\n"));
 
   // Check if current directory is a Vincent package
   const currentProject = isVincentProject(process.cwd());
 
   if (!currentProject.isProject) {
-    console.error(chalk.red('❌ Current directory is not a Vincent package'));
+    console.error(chalk.red("❌ Current directory is not a Vincent package"));
     console.log(
       chalk.gray(
-        'Run this command from within a Vincent tool or policy directory'
+        "Run this command from within a Vincent tool or policy directory"
       )
     );
     process.exit(1);
@@ -99,21 +99,21 @@ async function cleanCurrentPackage() {
   console.log(chalk.cyan(`📁 Package: ${currentProject.packageName}`));
 
   // Clean the dist and generated directories
-  const distPath = path.join(currentProject.path, 'dist');
-  const generatedPath = path.join(currentProject.path, 'src', 'generated');
+  const distPath = path.join(currentProject.path, "dist");
+  const generatedPath = path.join(currentProject.path, "src", "generated");
 
   try {
     if (fs.existsSync(distPath)) {
       fs.rmSync(distPath, { recursive: true, force: true });
-      console.log(chalk.green('✅ Removed dist directory'));
+      console.log(chalk.green("✅ Removed dist directory"));
     }
 
     if (fs.existsSync(generatedPath)) {
       fs.rmSync(generatedPath, { recursive: true, force: true });
-      console.log(chalk.green('✅ Removed src/generated directory'));
+      console.log(chalk.green("✅ Removed src/generated directory"));
     }
 
-    console.log(chalk.green.bold('\n✅ Package cleaned successfully'));
+    console.log(chalk.green.bold("\n✅ Package cleaned successfully"));
   } catch (error) {
     console.error(chalk.red(`❌ Error cleaning package: ${error.message}`));
     process.exit(1);
@@ -127,7 +127,7 @@ async function buildProject(type, projectPath) {
   if (!esbuild || !buildConfig) {
     console.error(
       chalk.red(
-        '❌ Build dependencies not available. Please ensure esbuild is installed.'
+        "❌ Build dependencies not available. Please ensure esbuild is installed."
       )
     );
     process.exit(1);
@@ -143,30 +143,35 @@ async function buildProject(type, projectPath) {
     process.chdir(targetPath);
 
     const { baseConfig, getPlugins, logBuildResults } = buildConfig;
-    const { generateLitAction } = require('../lit-action-generator');
+    const { generateLitAction } = require("../lit-action-generator");
 
     // Generate lit-action.ts before building
     generateLitAction(type);
 
     // Verify required files exist before proceeding
-    if (!fs.existsSync('./tsconfig.json')) {
+    if (!fs.existsSync("./tsconfig.json")) {
       throw new Error(`tsconfig.json not found in ${targetPath}`);
     }
-    if (!fs.existsSync('./src/generated/lit-action.ts')) {
+    if (!fs.existsSync("./src/generated/lit-action.ts")) {
       throw new Error(
         `lit-action.ts not found in ${targetPath}/src/generated/`
       );
     }
 
-    await esbuild
-      .build({
-        ...baseConfig,
-        tsconfig: './tsconfig.json',
-        entryPoints: ['./src/generated/lit-action.ts'],
-        outdir: './src/generated/',
-        plugins: getPlugins(type),
-      })
-      .then(logBuildResults);
+    const result = await esbuild.build({
+      ...baseConfig,
+      tsconfig: "./tsconfig.json",
+      entryPoints: ["./src/generated/lit-action.ts"],
+      outdir: "./src/generated/",
+      plugins: getPlugins(type),
+    });
+
+    await logBuildResults(result);
+
+    fs.writeFileSync(
+      `./esBuildMetafile.json`,
+      JSON.stringify(result.metafile, null, 2)
+    );
 
     console.log(chalk.green.bold(`\n✅ Vincent ${type} built successfully`));
     console.log(chalk.gray(`📁 Built in: ${targetPath}`));
@@ -187,23 +192,23 @@ async function deployProject(type, projectPath) {
   const targetPath = projectPath;
 
   try {
-    console.log(chalk.cyan('\n🚀 Deploying lit action to IPFS...\n'));
+    console.log(chalk.cyan("\n🚀 Deploying lit action to IPFS...\n"));
 
     // Change to project directory for deployment
     process.chdir(targetPath);
 
     // Import deploy function and call with project-specific path
-    const deployLitAction = require('../deploy-lit-action');
+    const deployLitAction = require("../deploy-lit-action");
     await deployLitAction({
-      generatedDir: path.join(targetPath, 'src/generated'),
-      outputFile: 'lit-action.js',
+      generatedDir: path.join(targetPath, "src/generated"),
+      outputFile: "lit-action.js",
       projectType: type,
     });
 
-    console.log(chalk.green.bold('\n✅ Lit action deployed successfully'));
+    console.log(chalk.green.bold("\n✅ Lit action deployed successfully"));
     console.log(chalk.gray(`📁 Deployed from: ${targetPath}`));
   } catch (error) {
-    console.error(chalk.red('\n❌ Error in deploy process:'), error);
+    console.error(chalk.red("\n❌ Error in deploy process:"), error);
     throw error;
   } finally {
     // Always restore original working directory
@@ -214,5 +219,5 @@ async function deployProject(type, projectPath) {
 module.exports = {
   buildCurrentPackage,
   deployCurrentPackage,
-  cleanCurrentPackage
+  cleanCurrentPackage,
 };

--- a/src/templates/policy/package.json
+++ b/src/templates/policy/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@lit-protocol/vincent-scaffold-sdk": "^1.1.6",
+    "@lit-protocol/vincent-scaffold-sdk": "^1.1.7-alpha.0",
     "@lit-protocol/vincent-tool-sdk": "^1.0.1"
   },
   "exports": {

--- a/src/templates/tool/package.json
+++ b/src/templates/tool/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@lit-protocol/vincent-scaffold-sdk": "^1.1.6",
+    "@lit-protocol/vincent-scaffold-sdk": "^1.1.7-alpha.0",
     "@lit-protocol/vincent-tool-sdk": "^1.0.1"
   },
   "exports": {


### PR DESCRIPTION
This will output a esBuildMetafile.json to the root dir of each tool or policy.  you can then feed this into https://esbuild.github.io/analyze/ to see what's taking up all the space in your bundle.  example for safe multisig: 
<img width="2168" height="1340" alt="Screenshot 2025-07-16 at 6 10 00 PM" src="https://github.com/user-attachments/assets/5946d6e0-43a9-4a08-ab3f-23a9de7eab9d" />
