### PR TITLE
fix nonce issue in signAuthorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/vincent-scaffold-sdk",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Shared build configuration and utilities for Vincent tools and policies",
   "main": "index.js",
   "bin": {

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
@@ -165,10 +165,12 @@ export class LitActionsSmartSigner implements SmartAccountSigner {
         ethers.utils.RLP.encode([
           ethers.utils.hexlify(chainId),
           contractAddress,
-          ethers.utils.hexlify(nonce),
+          nonce ? ethers.utils.hexlify(nonce) : "0x",
         ]),
       ])
     );
+
+    // console.log("hash in signAuthorization", hash);
 
     const sig = await Lit.Actions.signAndCombineEcdsa({
       toSign: ethers.utils.arrayify(hash),

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/sponsoredGasContractCall.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/sponsoredGasContractCall.ts
@@ -148,7 +148,7 @@ export const sponsoredGasContractCall = async ({
 
   // getting the entry point from the smart account client so we can send the user operation
   const entryPoint = smartAccountClient.account.getEntryPoint();
-  console.log("Entry point", entryPoint);
+  // console.log("Entry point", entryPoint);
 
   // send the user operation with EIP-7702 delegation in a runOnce
   // so that we don't submit it more than once

--- a/src/templates/policy/package.json
+++ b/src/templates/policy/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@lit-protocol/vincent-scaffold-sdk": "^1.1.7",
+    "@lit-protocol/vincent-scaffold-sdk": "^1.1.8",
     "@lit-protocol/vincent-tool-sdk": "^1.0.1"
   },
   "exports": {

--- a/src/templates/tool/package.json
+++ b/src/templates/tool/package.json
@@ -19,7 +19,7 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@lit-protocol/vincent-scaffold-sdk": "^1.1.7",
+    "@lit-protocol/vincent-scaffold-sdk": "^1.1.8",
     "@lit-protocol/vincent-tool-sdk": "^1.0.1"
   },
   "exports": {


### PR DESCRIPTION
simple fix - our signAuthorization method needs to work just like the viem reference implementation here https://github.com/wevm/viem/blob/main/src/utils/authorization/hashAuthorization.ts#L33

without this fix, gas sponsorship fails when nonce == 0.  We had to stop using just `nonce` and instead use `nonce ? ethers.utils.hexlify(nonce) : "0x",` just like viem.