### PR TITLE
feat: add function to wait for bundle tx hash

### DIFF
--- a/src/exports/la-utils/index.ts
+++ b/src/exports/la-utils/index.ts
@@ -1,6 +1,7 @@
 import { yellowstoneConfig } from "./la-chain/yellowstone/yellowstoneConfig";
 import { contractCall } from "./la-transactions/handlers/contractCall";
 import { sponsoredGasContractCall } from "./la-transactions/handlers/sponsoredGas/sponsoredGasContractCall";
+import { waitForUserOp } from "./la-transactions/handlers/sponsoredGas/waitForUserOp";
 import { getAlchemyChainConfig } from "./la-helpers/getAlchemyChainConfig";
 import { nativeSend } from "./la-transactions/handlers/nativeSend";
 import { getNonce } from "./la-transactions/primitive/getNonce";
@@ -13,6 +14,7 @@ export {
   yellowstoneConfig,
   contractCall,
   sponsoredGasContractCall,
+  waitForUserOp,
   nativeSend,
   getNonce,
   sendTx,
@@ -29,6 +31,7 @@ export const laUtils = {
     handler: {
       contractCall,
       sponsoredGasContractCall,
+      waitForUserOp,
       nativeSend,
     },
     primitive: {

--- a/src/exports/la-utils/la-transactions/handlers/contractCall.ts
+++ b/src/exports/la-utils/la-transactions/handlers/contractCall.ts
@@ -1,3 +1,5 @@
+import { ethers } from "ethers";
+
 import { yellowstoneConfig } from "../../la-chain/yellowstone/yellowstoneConfig";
 import { signTx } from "../primitive/signTx";
 import { sendTx } from "../primitive/sendTx";
@@ -30,7 +32,7 @@ export const contractCall = async ({
   chainId,
   gasBumpPercentage,
 }: {
-  provider: any;
+  provider: ethers.providers.JsonRpcProvider;
   pkpPublicKey: string;
   callerAddress: string;
   abi: any[];

--- a/src/exports/la-utils/la-transactions/handlers/nativeSend.ts
+++ b/src/exports/la-utils/la-transactions/handlers/nativeSend.ts
@@ -1,3 +1,5 @@
+import { ethers } from "ethers";
+
 import { signTx } from "../primitive/signTx";
 import { sendTx } from "../primitive/sendTx";
 import { toEthAddress } from "../../la-helpers/toEthAddress";
@@ -19,7 +21,7 @@ export const nativeSend = async ({
   amount,
   to,
 }: {
-  provider: InstanceType<typeof ethers.providers.JsonRpcProvider>;
+  provider: ethers.providers.JsonRpcProvider;
   pkpPublicKey: string;
   amount: string;
   to: string;

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers';
+import { ethers } from "ethers";
 
 /**
  * LitActionsSmartSigner for EIP-7702 delegated transactions

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/litActionSmartSigner.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 /**
  * LitActionsSmartSigner for EIP-7702 delegated transactions
  *

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/sponsoredGasContractCall.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/sponsoredGasContractCall.ts
@@ -14,9 +14,10 @@ import { getAlchemyChainConfig } from "../../../la-helpers/getAlchemyChainConfig
  * @param functionName - The name of the function to call
  * @param args - The arguments to pass to the function
  * @param overrides - Optional transaction overrides (value)
- * @param chainId - Optional chain ID (defaults to yellowstoneConfig.id)
+ * @param chainId - Chain ID (defaults to yellowstoneConfig.id)
  * @param eip7702AlchemyApiKey - The Alchemy API key for gas sponsorship
  * @param eip7702AlchemyPolicyId - The Alchemy policy ID for gas sponsorship
+ * @param eip7702WaitForBundleTx - Optional flag to wait for the bundle transaction to be mined. Defaults to false.
  * @returns The UserOperation hash.  You must use the alchemy smartAccountClient.waitForUserOperationTransaction() to convert the userOp into a txHash.
  */
 export const sponsoredGasContractCall = async ({

--- a/src/exports/la-utils/la-transactions/handlers/sponsoredGas/waitForUserOp.ts
+++ b/src/exports/la-utils/la-transactions/handlers/sponsoredGas/waitForUserOp.ts
@@ -1,0 +1,55 @@
+import { alchemy } from '@account-kit/infra';
+import { LitActionsSmartSigner } from './litActionSmartSigner';
+import { createModularAccountV2Client } from '@account-kit/smart-contracts';
+import { getAlchemyChainConfig } from '../../../la-helpers/getAlchemyChainConfig';
+
+export const waitForUserOp = async ({
+  pkpPublicKey,
+  chainId,
+  eip7702AlchemyApiKey,
+  eip7702AlchemyPolicyId,
+  userOp,
+}: {
+  pkpPublicKey: string;
+  chainId: number;
+  eip7702AlchemyApiKey: string;
+  eip7702AlchemyPolicyId: string;
+  userOp: `0x${string}`;
+}) => {
+  if (!eip7702AlchemyApiKey || !eip7702AlchemyPolicyId) {
+    throw new Error(
+      "EIP7702 Alchemy API key and policy ID are required when using Alchemy for gas sponsorship"
+    );
+  }
+
+  if (!chainId) {
+    throw new Error(
+      "Chain ID is required when using Alchemy for gas sponsorship"
+    );
+  }
+
+  // Create LitActionsSmartSigner for EIP-7702
+  const litSigner = new LitActionsSmartSigner({
+    pkpPublicKey,
+    chainId,
+  });
+
+  // Get the Alchemy chain configuration
+  const alchemyChain = getAlchemyChainConfig(chainId);
+
+  // Create the Smart Account Client with EIP-7702 mode
+  const smartAccountClient = await createModularAccountV2Client({
+    mode: '7702' as const,
+    transport: alchemy({ apiKey: eip7702AlchemyApiKey }),
+    chain: alchemyChain,
+    signer: litSigner,
+    policyId: eip7702AlchemyPolicyId,
+  });
+
+  // Wait for the bundle to be mined
+  const bundleHas = await smartAccountClient.waitForUserOperationTransaction({
+    hash: userOp,
+  });
+
+  return bundleHas;
+};


### PR DESCRIPTION
This PR adds `waitForUserOp` so consumers of abilities that support EIP-7702 can import it and wait until the bundler includes their user op into an actual tx they can wait

Bonus 1: made `eip7702AlchemyApiKey`, `eip7702AlchemyPolicyId` and `chain` required in the args param. We were throwing when those are not provided, it does not make sense to have them optional at compile time
Bonus 2: Got `ethers` undefined error in lit action smart signer. Adding that import fixed it